### PR TITLE
Changed footer text to 'Privacy Policy and Contact'

### DIFF
--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -7,7 +7,7 @@ const Footer = () => {
     <footer className="footer">
       <p>© {new Date().getFullYear()} Libre Express</p>
       <a href="/politica-de-privacidad" className="footer-link">
-        Política de Privacidad
+        Política de Privacidad y Contacto
       </a>
     </footer>
   );


### PR DESCRIPTION
I changed the link text in the Footer from "Privacy Policy" to "Privacy Policy and Contact" to reflect the inclusion of contact information within the policy.